### PR TITLE
Install fix

### DIFF
--- a/lib/pypi.js
+++ b/lib/pypi.js
@@ -29,7 +29,7 @@
 
 var xmlrpc = require('xmlrpc');
 
-var DEFAULT_URL = 'https://pypi.org';
+var DEFAULT_URL = 'https://pypi.python.org/pypi';
 
 function Client(url) {
   if (url == null) {

--- a/lib/virtualenv.js
+++ b/lib/virtualenv.js
@@ -159,23 +159,25 @@ VirtualEnv.prototype._find = function _find(callback) {
     });
     if (!latestValidVersion) return callback(new Error("virtualenv " + targetVersion + " not found in " + versions.toString()));
 
-    // Figure out the tarball URL for this version.
-    client.getReleaseUrls("virtualenv", latestValidVersion, function(urls) {
-      if (!urls || !urls.length) return callback(new Error("unable to find URL for virtualenv " + latestValidVersion));
-      var tarballUrl;
-      urls.some(function(url) {
-        if (/\.tar\.gz$/.test(url.url)) {
-          tarballUrl = url.url;
-          return true;
-        }
-      });
-      if (!tarballUrl) return callback(new Error("unable to find a tarball for virtualenv " + latestValidVersion));
-      callback(null, latestValidVersion, tarballUrl);
+    setTimeout(function(){
+      // Figure out the tarball URL for this version.
+      client.getReleaseUrls("virtualenv", latestValidVersion, function(urls) {
+        if (!urls || !urls.length) return callback(new Error("unable to find URL for virtualenv " + latestValidVersion));
+        var tarballUrl;
+        urls.some(function(url) {
+          if (/\.tar\.gz$/.test(url.url)) {
+            tarballUrl = url.url;
+            return true;
+          }
+        });
+        if (!tarballUrl) return callback(new Error("unable to find a tarball for virtualenv " + latestValidVersion));
+        callback(null, latestValidVersion, tarballUrl);
 
-    // Propagate pypi error callback.
-    }, function(err) {
-      callback(new Error("unable to retrieve release URLs for virtualenv " + latestValidVersion));
-    });
+      // Propagate pypi error callback.
+      }, function(err) {
+        callback(new Error("unable to retrieve release URLs for virtualenv " + latestValidVersion));
+      });
+    }, 1500);
 
   // Propagate pypi error callback.
   }, function(err) {


### PR DESCRIPTION
client.getReleaseUrls would not complete since it was getting a too many requests error. Added timeout to avoid rate limit.